### PR TITLE
Add base stats for Valencia forms

### DIFF
--- a/data/pokemon/base_stats/forms/bellossom_valencia.asm
+++ b/data/pokemon/base_stats/forms/bellossom_valencia.asm
@@ -1,1 +1,21 @@
-INCLUDE "data/pokemon/base_stats/johto/bellossom.asm"
+	db 0 ; species ID placeholder
+
+	db  75,  80,  85,  50,  90, 100
+	evs  0,   0,   0,   0,   0,   3
+	;   hp  atk  def  spd  sat  sdf
+
+	db GRASS, GRASS ; type
+	db 45 ; catch rate
+	db 184 ; base exp
+	dw NO_ITEM, NO_ITEM ; items
+	db GENDER_F50 ; gender ratio
+	db 20 ; step cycles to hatch
+	INCBIN "gfx/pokemon/forms/bellossom_valencia/front.dimensions"
+	db CHLOROPHYLL, GRASSY_SURGE ; wBaseAbility1, wBaseAbility2
+	dw NULL ; Padding left-over from the unused back pic
+	db GROWTH_MEDIUM_SLOW ; growth rate
+	dn EGG_PLANT, EGG_PLANT ; egg groups
+
+	; tm/hm learnset
+	tmhm TOXIC, BULLET_SEED, SUNNY_DAY, HYPER_BEAM, PROTECT, GIGA_DRAIN, SAFEGUARD, DAZZLING_GLEAM, SOLARBEAM, DOUBLE_TEAM, SLUDGE_BOMB, FACADE, REST, ATTRACT, ENERGY_BALL, FLING, ENDURE, DRAIN_PUNCH, GIGA_IMPACT, FLASH, SWORDS_DANCE, SLEEP_TALK, GRASS_KNOT, SWAGGER, SUBSTITUTE, CUT
+	; end

--- a/data/pokemon/base_stats/forms/bellsprout_valencia.asm
+++ b/data/pokemon/base_stats/forms/bellsprout_valencia.asm
@@ -1,1 +1,21 @@
-INCLUDE "data/pokemon/base_stats/kanto/bellsprout.asm"
+	db 0 ; species ID placeholder
+
+	db  50,  75,  35,  40,  70,  30
+	evs  0,   1,   0,   0,   0,   0
+	;   hp  atk  def  spd  sat  sdf
+
+	db GRASS, POISON ; type
+	db 255 ; catch rate
+	db 84 ; base exp
+	dw NO_ITEM, NO_ITEM ; items
+	db GENDER_F50 ; gender ratio
+	db 20 ; step cycles to hatch
+	INCBIN "gfx/pokemon/forms/bellsprout_valencia/front.dimensions"
+	db CHLOROPHYLL, GLUTTONY ; wBaseAbility1, wBaseAbility2
+	dw NULL ; Padding left-over from the unused back pic
+	db GROWTH_MEDIUM_SLOW ; growth rate
+	dn EGG_PLANT, EGG_PLANT ; egg groups
+
+	; tm/hm learnset
+	tmhm BULLET_SEED, SUNNY_DAY, PROTECT, GIGA_DRAIN, SOLARBEAM, DOUBLE_TEAM, REFLECT, SLUDGE_BOMB, FACADE, REST, ATTRACT, THIEF, ENERGY_BALL, ENDURE, FLASH, SWORDS_DANCE, SLEEP_TALK, POISON_JAB, GRASS_KNOT, SWAGGER, SUBSTITUTE, CUT
+	; end

--- a/data/pokemon/base_stats/forms/butterfree_valencia.asm
+++ b/data/pokemon/base_stats/forms/butterfree_valencia.asm
@@ -1,1 +1,21 @@
-INCLUDE "data/pokemon/base_stats/kanto/butterfree.asm"
+	db 0 ; species ID placeholder
+
+	db  60,  45,  50,  70,  80,  80
+	evs  0,   0,   0,   0,   2,   1
+	;   hp  atk  def  spd  sat  sdf
+
+	db BUG, FLYING ; type
+	db 45 ; catch rate
+	db 160 ; base exp
+	dw NO_ITEM, SILVERPOWDER ; items
+	db GENDER_F50 ; gender ratio
+	db 15 ; step cycles to hatch
+	INCBIN "gfx/pokemon/forms/butterfree_valencia/front.dimensions"
+	db COMPOUNDEYES, TINTED_LENS ; wBaseAbility1, wBaseAbility2
+	dw NULL ; Padding left-over from the unused back pic
+	db GROWTH_MEDIUM_FAST ; growth rate
+	dn EGG_BUG, EGG_BUG ; egg groups
+
+	; tm/hm learnset
+	tmhm SUNNY_DAY, HYPER_BEAM, PROTECT, RAIN_DANCE, GIGA_DRAIN, SAFEGUARD, SOLARBEAM, PSYCHIC_M, SHADOW_BALL, DOUBLE_TEAM, AERIAL_ACE, FACADE, REST, ATTRACT, THIEF, SKILL_SWAP, ROOST, ENERGY_BALL, ENDURE, BUG_BUZZ, GIGA_IMPACT, FLASH, PSYCH_UP, SLEEP_TALK, DREAM_EATER, SWAGGER, U_TURN, SUBSTITUTE, DEFOG
+	; end

--- a/data/pokemon/base_stats/forms/caterpie_valencia.asm
+++ b/data/pokemon/base_stats/forms/caterpie_valencia.asm
@@ -1,1 +1,25 @@
-INCLUDE "data/pokemon/base_stats/kanto/caterpie.asm"
+	db 0 ; species ID placeholder
+
+	db  45,  30,  35,  45,  20,  20
+	evs  1,   0,   0,   0,   0,   0
+	;   hp  atk  def  spd  sat  sdf
+
+	db BUG, BUG ; type
+	db 255 ; catch rate
+	db 53 ; base exp
+	dw NO_ITEM, NO_ITEM ; items
+	db GENDER_F50 ; gender ratio
+	db 15 ; step cycles to hatch
+	INCBIN "gfx/pokemon/forms/caterpie_valencia/front.dimensions"
+	db SHIELD_DUST, RUN_AWAY ; wBaseAbility1, wBaseAbility2
+	dw NULL ; Padding left-over from the unused back pic
+	db GROWTH_MEDIUM_FAST ; growth rate
+	dn EGG_BUG, EGG_BUG ; egg groups
+
+	; tm/hm learnset
+	tmhm
+
+
+
+
+	; end

--- a/data/pokemon/base_stats/forms/gloom_valencia.asm
+++ b/data/pokemon/base_stats/forms/gloom_valencia.asm
@@ -1,1 +1,21 @@
-INCLUDE "data/pokemon/base_stats/kanto/gloom.asm"
+	db 0 ; species ID placeholder
+
+	db  60,  65,  70,  40,  85,  75
+	evs  0,   0,   0,   0,   2,   0
+	;   hp  atk  def  spd  sat  sdf
+
+	db GRASS, POISON ; type
+	db 120 ; catch rate
+	db 132 ; base exp
+	dw NO_ITEM, NO_ITEM ; items
+	db GENDER_F50 ; gender ratio
+	db 20 ; step cycles to hatch
+	INCBIN "gfx/pokemon/forms/gloom_valencia/front.dimensions"
+	db CHLOROPHYLL, STENCH ; wBaseAbility1, wBaseAbility2
+	dw NULL ; Padding left-over from the unused back pic
+	db GROWTH_MEDIUM_SLOW ; growth rate
+	dn EGG_PLANT, EGG_PLANT ; egg groups
+
+	; tm/hm learnset
+	tmhm TOXIC, BULLET_SEED, SUNNY_DAY, PROTECT, GIGA_DRAIN, DAZZLING_GLEAM, SOLARBEAM, DOUBLE_TEAM, SLUDGE_BOMB, FACADE, REST, ATTRACT, ENERGY_BALL, FLING, ENDURE, DRAIN_PUNCH, FLASH, SWORDS_DANCE, SLEEP_TALK, GRASS_KNOT, SWAGGER, SUBSTITUTE, CUT
+	; end

--- a/data/pokemon/base_stats/forms/metapod_valencia.asm
+++ b/data/pokemon/base_stats/forms/metapod_valencia.asm
@@ -1,1 +1,25 @@
-INCLUDE "data/pokemon/base_stats/kanto/metapod.asm"
+	db 0 ; species ID placeholder
+
+	db  50,  20,  55,  30,  25,  25
+	evs  0,   0,   2,   0,   0,   0
+	;   hp  atk  def  spd  sat  sdf
+
+	db BUG, BUG ; type
+	db 120 ; catch rate
+	db 72 ; base exp
+	dw NO_ITEM, NO_ITEM ; items
+	db GENDER_F50 ; gender ratio
+	db 15 ; step cycles to hatch
+	INCBIN "gfx/pokemon/forms/metapod_valencia/front.dimensions"
+	db SHED_SKIN, SHED_SKIN ; wBaseAbility1, wBaseAbility2
+	dw NULL ; Padding left-over from the unused back pic
+	db GROWTH_MEDIUM_FAST ; growth rate
+	dn EGG_BUG, EGG_BUG ; egg groups
+
+	; tm/hm learnset
+	tmhm
+
+
+
+
+	; end

--- a/data/pokemon/base_stats/forms/oddish_valencia.asm
+++ b/data/pokemon/base_stats/forms/oddish_valencia.asm
@@ -1,1 +1,21 @@
-INCLUDE "data/pokemon/base_stats/kanto/oddish.asm"
+	db 0 ; species ID placeholder
+
+	db  45,  50,  55,  30,  75,  65
+	evs  0,   0,   0,   0,   1,   0
+	;   hp  atk  def  spd  sat  sdf
+
+	db GRASS, POISON ; type
+	db 255 ; catch rate
+	db 78 ; base exp
+	dw NO_ITEM, NO_ITEM ; items
+	db GENDER_F50 ; gender ratio
+	db 20 ; step cycles to hatch
+	INCBIN "gfx/pokemon/forms/oddish_valencia/front.dimensions"
+	db CHLOROPHYLL, RUN_AWAY ; wBaseAbility1, wBaseAbility2
+	dw NULL ; Padding left-over from the unused back pic
+	db GROWTH_MEDIUM_SLOW ; growth rate
+	dn EGG_PLANT, EGG_PLANT ; egg groups
+
+	; tm/hm learnset
+	tmhm TOXIC, BULLET_SEED, SUNNY_DAY, PROTECT, GIGA_DRAIN, DAZZLING_GLEAM, SOLARBEAM, DOUBLE_TEAM, SLUDGE_BOMB, FACADE, REST, ATTRACT, ENERGY_BALL, ENDURE, FLASH, SWORDS_DANCE, SLEEP_TALK, GRASS_KNOT, SWAGGER, SUBSTITUTE, CUT
+	; end

--- a/data/pokemon/base_stats/forms/paras_valencia.asm
+++ b/data/pokemon/base_stats/forms/paras_valencia.asm
@@ -1,1 +1,21 @@
-INCLUDE "data/pokemon/base_stats/kanto/paras.asm"
+	db 0 ; species ID placeholder
+
+	db  35,  70,  55,  25,  45,  55
+	evs  0,   1,   0,   0,   0,   0
+	;   hp  atk  def  spd  sat  sdf
+
+	db BUG, GRASS ; type
+	db 190 ; catch rate
+	db 70 ; base exp
+	dw TINYMUSHROOM, BIG_MUSHROOM ; items
+	db GENDER_F50 ; gender ratio
+	db 20 ; step cycles to hatch
+	INCBIN "gfx/pokemon/forms/paras_valencia/front.dimensions"
+	db EFFECT_SPORE, DRY_SKIN ; wBaseAbility1, wBaseAbility2
+	dw NULL ; Padding left-over from the unused back pic
+	db GROWTH_MEDIUM_FAST ; growth rate
+	dn EGG_BUG, EGG_PLANT ; egg groups
+
+	; tm/hm learnset
+	tmhm BULLET_SEED, SUNNY_DAY, LIGHT_SCREEN, PROTECT, GIGA_DRAIN, SOLARBEAM, DIG, BRICK_BREAK, DOUBLE_TEAM, SLUDGE_BOMB, AERIAL_ACE, FACADE, REST, ATTRACT, THIEF, FALSE_SWIPE, ENDURE, FLASH, SWORDS_DANCE, X_SCISSOR, SLEEP_TALK, GRASS_KNOT, SWAGGER, SUBSTITUTE, CUT, ROCK_SMASH
+	; end

--- a/data/pokemon/base_stats/forms/parasect_valencia.asm
+++ b/data/pokemon/base_stats/forms/parasect_valencia.asm
@@ -1,1 +1,21 @@
-INCLUDE "data/pokemon/base_stats/kanto/parasect.asm"
+	db 0 ; species ID placeholder
+
+	db  60,  95,  80,  30,  60,  80
+	evs  0,   2,   1,   0,   0,   0
+	;   hp  atk  def  spd  sat  sdf
+
+	db BUG, GRASS ; type
+	db 75 ; catch rate
+	db 128 ; base exp
+	dw TINYMUSHROOM, BIG_MUSHROOM ; items
+	db GENDER_F50 ; gender ratio
+	db 20 ; step cycles to hatch
+	INCBIN "gfx/pokemon/forms/parasect_valencia/front.dimensions"
+	db EFFECT_SPORE, DRY_SKIN ; wBaseAbility1, wBaseAbility2
+	dw NULL ; Padding left-over from the unused back pic
+	db GROWTH_MEDIUM_FAST ; growth rate
+	dn EGG_BUG, EGG_PLANT ; egg groups
+
+	; tm/hm learnset
+	tmhm BULLET_SEED, SUNNY_DAY, HYPER_BEAM, LIGHT_SCREEN, PROTECT, GIGA_DRAIN, SOLARBEAM, DIG, BRICK_BREAK, DOUBLE_TEAM, SLUDGE_BOMB, AERIAL_ACE, FACADE, REST, ATTRACT, THIEF, ENERGY_BALL, FALSE_SWIPE, ENDURE, GIGA_IMPACT, FLASH, SWORDS_DANCE, X_SCISSOR, SLEEP_TALK, GRASS_KNOT, SWAGGER, SUBSTITUTE, CUT, ROCK_SMASH
+	; end

--- a/data/pokemon/base_stats/forms/victreebel_valencia.asm
+++ b/data/pokemon/base_stats/forms/victreebel_valencia.asm
@@ -1,1 +1,21 @@
-INCLUDE "data/pokemon/base_stats/kanto/victreebel.asm"
+	db 0 ; species ID placeholder
+
+	db  80, 105,  65,  70, 100,  60
+	evs  0,   3,   0,   0,   0,   0
+	;   hp  atk  def  spd  sat  sdf
+
+	db GRASS, POISON ; type
+	db 45 ; catch rate
+	db 191 ; base exp
+	dw NO_ITEM, NO_ITEM ; items
+	db GENDER_F50 ; gender ratio
+	db 20 ; step cycles to hatch
+	INCBIN "gfx/pokemon/forms/victreebel_valencia/front.dimensions"
+	db CHLOROPHYLL, GLUTTONY ; wBaseAbility1, wBaseAbility2
+	dw NULL ; Padding left-over from the unused back pic
+	db GROWTH_MEDIUM_SLOW ; growth rate
+	dn EGG_PLANT, EGG_PLANT ; egg groups
+
+	; tm/hm learnset
+	tmhm BULLET_SEED, SUNNY_DAY, HYPER_BEAM, PROTECT, GIGA_DRAIN, SOLARBEAM, DOUBLE_TEAM, REFLECT, SLUDGE_BOMB, FACADE, REST, ATTRACT, THIEF, ENERGY_BALL, ENDURE, GIGA_IMPACT, FLASH, SWORDS_DANCE, SLEEP_TALK, POISON_JAB, GRASS_KNOT, SWAGGER, SUBSTITUTE, CUT
+	; end

--- a/data/pokemon/base_stats/forms/vileplume_valencia.asm
+++ b/data/pokemon/base_stats/forms/vileplume_valencia.asm
@@ -1,1 +1,21 @@
-INCLUDE "data/pokemon/base_stats/kanto/vileplume.asm"
+	db 0 ; species ID placeholder
+
+	db  75,  80,  85,  50, 100,  90
+	evs  0,   0,   0,   0,   3,   0
+	;   hp  atk  def  spd  sat  sdf
+
+	db GRASS, POISON ; type
+	db 45 ; catch rate
+	db 184 ; base exp
+	dw NO_ITEM, NO_ITEM ; items
+	db GENDER_F50 ; gender ratio
+	db 20 ; step cycles to hatch
+	INCBIN "gfx/pokemon/forms/vileplume_valencia/front.dimensions"
+	db CHLOROPHYLL, EFFECT_SPORE ; wBaseAbility1, wBaseAbility2
+	dw NULL ; Padding left-over from the unused back pic
+	db GROWTH_MEDIUM_SLOW ; growth rate
+	dn EGG_PLANT, EGG_PLANT ; egg groups
+
+	; tm/hm learnset
+	tmhm TOXIC, BULLET_SEED, SUNNY_DAY, HYPER_BEAM, PROTECT, GIGA_DRAIN, SAFEGUARD, DAZZLING_GLEAM, SOLARBEAM, DOUBLE_TEAM, SLUDGE_BOMB, FACADE, REST, ATTRACT, ENERGY_BALL, FLING, ENDURE, DRAIN_PUNCH, GIGA_IMPACT, FLASH, SWORDS_DANCE, SLEEP_TALK, GRASS_KNOT, SWAGGER, SUBSTITUTE, CUT
+	; end

--- a/data/pokemon/base_stats/forms/weepinbell_valencia.asm
+++ b/data/pokemon/base_stats/forms/weepinbell_valencia.asm
@@ -1,1 +1,21 @@
-INCLUDE "data/pokemon/base_stats/kanto/weepinbell.asm"
+	db 0 ; species ID placeholder
+
+	db  65,  90,  50,  55,  85,  45
+	evs  0,   2,   0,   0,   0,   0
+	;   hp  atk  def  spd  sat  sdf
+
+	db GRASS, POISON ; type
+	db 120 ; catch rate
+	db 151 ; base exp
+	dw NO_ITEM, NO_ITEM ; items
+	db GENDER_F50 ; gender ratio
+	db 20 ; step cycles to hatch
+	INCBIN "gfx/pokemon/forms/weepinbell_valencia/front.dimensions"
+	db CHLOROPHYLL, GLUTTONY ; wBaseAbility1, wBaseAbility2
+	dw NULL ; Padding left-over from the unused back pic
+	db GROWTH_MEDIUM_SLOW ; growth rate
+	dn EGG_PLANT, EGG_PLANT ; egg groups
+
+	; tm/hm learnset
+	tmhm BULLET_SEED, SUNNY_DAY, PROTECT, GIGA_DRAIN, SOLARBEAM, DOUBLE_TEAM, REFLECT, SLUDGE_BOMB, FACADE, REST, ATTRACT, THIEF, ENERGY_BALL, ENDURE, FLASH, SWORDS_DANCE, SLEEP_TALK, POISON_JAB, GRASS_KNOT, SWAGGER, SUBSTITUTE, CUT
+	; end


### PR DESCRIPTION
## Summary
- expand Valencia form base stats to explicitly include data
- point each Valencia form's sprite dimensions to its own gfx folder

## Testing
- `make` *(fails: rgbasm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a754aec83258e51b49cada43c7b