### PR TITLE
Add challenge mode check command and trainer swap

### DIFF
--- a/constants/ram_constants.asm
+++ b/constants/ram_constants.asm
@@ -75,8 +75,9 @@ DEF GBPRINTER_DARKER   EQU $60
 DEF GBPRINTER_DARKEST  EQU $7f
 
 ; wOptions2::
-	const_def
-	const MENU_ACCOUNT ; 0
+        const_def
+        const MENU_ACCOUNT   ; 0
+        const CHALLENGE_MODE ; 1
 
 ; wDST::
 DEF DST_F EQU 7

--- a/data/default_options.asm
+++ b/data/default_options.asm
@@ -9,8 +9,8 @@ DefaultOptions:
 	db 1 << FAST_TEXT_DELAY_F
 ; wGBPrinterBrightness: normal
 	db GBPRINTER_NORMAL
-; wOptions2: menu account on
-	db 1 << MENU_ACCOUNT
+; wOptions2: menu account on, challenge mode off
+        db 1 << MENU_ACCOUNT
 
 	db $00
 	db $00

--- a/docs/event_commands.md
+++ b/docs/event_commands.md
@@ -561,3 +561,6 @@ If <code><i>item_id</i></code> = `USE_SCRIPT_VAR`, then it uses `[wScriptVar]` i
 
 
 ## `$A9`: `checksave`
+
+## `$B0`: `checkcm`
+Sets `VAR` to `TRUE` if Challenge Mode is enabled; otherwise `FALSE`.

--- a/engine/menus/options_menu.asm
+++ b/engine/menus/options_menu.asm
@@ -3,11 +3,11 @@
 	const OPT_TEXT_SPEED    ; 0
 	const OPT_BATTLE_SCENE  ; 1
 	const OPT_BATTLE_STYLE  ; 2
-	const OPT_SOUND         ; 3
-	const OPT_PRINT         ; 4
-	const OPT_MENU_ACCOUNT  ; 5
-	const OPT_FRAME         ; 6
-	const OPT_CANCEL        ; 7
+        const OPT_SOUND         ; 3
+        const OPT_MENU_ACCOUNT  ; 4
+        const OPT_CHALLENGE_MODE ; 5
+        const OPT_FRAME         ; 6
+        const OPT_CANCEL        ; 7
 DEF NUM_OPTIONS EQU const_value ; 8
 
 _Option:
@@ -80,13 +80,13 @@ StringOptions:
 	db "        :<LF>"
 	db "BATTLE STYLE<LF>"
 	db "        :<LF>"
-	db "SOUND<LF>"
-	db "        :<LF>"
-	db "PRINT<LF>"
-	db "        :<LF>"
-	db "MENU ACCOUNT<LF>"
-	db "        :<LF>"
-	db "FRAME<LF>"
+        db "SOUND<LF>"
+        db "        :<LF>"
+        db "MENU ACCOUNT<LF>"
+        db "        :<LF>"
+        db "CHALLENGE MODE<LF>"
+        db "        :<LF>"
+        db "FRAME<LF>"
 	db "        :TYPE<LF>"
 	db "CANCEL@"
 
@@ -98,9 +98,9 @@ GetOptionPointer:
 	dw Options_TextSpeed
 	dw Options_BattleScene
 	dw Options_BattleStyle
-	dw Options_Sound
-	dw Options_Print
-	dw Options_MenuAccount
+        dw Options_Sound
+        dw Options_MenuAccount
+        dw Options_ChallengeMode
 	dw Options_Frame
 	dw Options_Cancel
 
@@ -311,142 +311,78 @@ Options_Sound:
 .Mono:   db "MONO  @"
 .Stereo: db "STEREO@"
 
-	const_def
-	const OPT_PRINT_LIGHTEST ; 0
-	const OPT_PRINT_LIGHTER  ; 1
-	const OPT_PRINT_NORMAL   ; 2
-	const OPT_PRINT_DARKER   ; 3
-	const OPT_PRINT_DARKEST  ; 4
-
-Options_Print:
-	call GetPrinterSetting
-	ldh a, [hJoyPressed]
-	bit B_PAD_LEFT, a
-	jr nz, .LeftPressed
-	bit B_PAD_RIGHT, a
-	jr z, .NonePressed
-	ld a, c
-	cp OPT_PRINT_DARKEST
-	jr c, .Increase
-	ld c, OPT_PRINT_LIGHTEST - 1
-
-.Increase:
-	inc c
-	ld a, e
-	jr .Save
-
-.LeftPressed:
-	ld a, c
-	and a
-	jr nz, .Decrease
-	ld c, OPT_PRINT_DARKEST + 1
-
-.Decrease:
-	dec c
-	ld a, d
-
-.Save:
-	ld b, a
-	ld [wGBPrinterBrightness], a
-
-.NonePressed:
-	ld b, 0
-	ld hl, .Strings
-	add hl, bc
-	add hl, bc
-	ld a, [hli]
-	ld d, [hl]
-	ld e, a
-	hlcoord 11, 11
-	rst PlaceString
-	and a
-	ret
-
-.Strings:
-; entries correspond to OPT_PRINT_* constants
-	dw .Lightest
-	dw .Lighter
-	dw .Normal
-	dw .Darker
-	dw .Darkest
-
-.Lightest: db "LIGHTEST@"
-.Lighter:  db "LIGHTER @"
-.Normal:   db "NORMAL  @"
-.Darker:   db "DARKER  @"
-.Darkest:  db "DARKEST @"
-
-GetPrinterSetting:
-; converts GBPRINTER_* value in a to OPT_PRINT_* value in c,
-; with previous/next GBPRINTER_* values in d/e
-	ld a, [wGBPrinterBrightness]
-	and a
-	jr z, .IsLightest
-	cp GBPRINTER_LIGHTER
-	jr z, .IsLight
-	cp GBPRINTER_DARKER
-	jr z, .IsDark
-	cp GBPRINTER_DARKEST
-	jr z, .IsDarkest
-	; none of the above
-	ld c, OPT_PRINT_NORMAL
-	lb de, GBPRINTER_LIGHTER, GBPRINTER_DARKER
-	ret
-
-.IsLightest:
-	ld c, OPT_PRINT_LIGHTEST
-	lb de, GBPRINTER_DARKEST, GBPRINTER_LIGHTER
-	ret
-
-.IsLight:
-	ld c, OPT_PRINT_LIGHTER
-	lb de, GBPRINTER_LIGHTEST, GBPRINTER_NORMAL
-	ret
-
-.IsDark:
-	ld c, OPT_PRINT_DARKER
-	lb de, GBPRINTER_NORMAL, GBPRINTER_DARKEST
-	ret
-
-.IsDarkest:
-	ld c, OPT_PRINT_DARKEST
-	lb de, GBPRINTER_DARKER, GBPRINTER_LIGHTEST
-	ret
-
 Options_MenuAccount:
-	ld hl, wOptions2
-	ldh a, [hJoyPressed]
-	bit B_PAD_LEFT, a
-	jr nz, .LeftPressed
-	bit B_PAD_RIGHT, a
-	jr z, .NonePressed
-	bit MENU_ACCOUNT, [hl]
-	jr nz, .ToggleOff
-	jr .ToggleOn
+        ld hl, wOptions2
+        ldh a, [hJoyPressed]
+        bit B_PAD_LEFT, a
+        jr nz, .LeftPressed
+        bit B_PAD_RIGHT, a
+        jr z, .NonePressed
+        bit MENU_ACCOUNT, [hl]
+        jr nz, .ToggleOff
+        jr .ToggleOn
 
 .LeftPressed:
-	bit MENU_ACCOUNT, [hl]
-	jr z, .ToggleOn
-	jr .ToggleOff
+        bit MENU_ACCOUNT, [hl]
+        jr z, .ToggleOn
+        jr .ToggleOff
 
 .NonePressed:
-	bit MENU_ACCOUNT, [hl]
-	jr nz, .ToggleOn
+        bit MENU_ACCOUNT, [hl]
+        jr nz, .ToggleOn
 
 .ToggleOff:
-	res MENU_ACCOUNT, [hl]
-	ld de, .Off
-	jr .Display
+        res MENU_ACCOUNT, [hl]
+        ld de, .Off
+        jr .Display
 
 .ToggleOn:
-	set MENU_ACCOUNT, [hl]
-	ld de, .On
+        set MENU_ACCOUNT, [hl]
+        ld de, .On
 
 .Display:
-	hlcoord 11, 13
-	rst PlaceString
-	and a
-	ret
+        hlcoord 11, 11
+        rst PlaceString
+        and a
+        ret
+
+.Off: db "OFF@"
+.On:  db "ON @"
+
+Options_ChallengeMode:
+        ld hl, wOptions2
+        ldh a, [hJoyPressed]
+        bit B_PAD_LEFT, a
+        jr nz, .LeftPressed
+        bit B_PAD_RIGHT, a
+        jr z, .NonePressed
+        bit CHALLENGE_MODE, [hl]
+        jr nz, .ToggleOff
+        jr .ToggleOn
+
+.LeftPressed:
+        bit CHALLENGE_MODE, [hl]
+        jr z, .ToggleOn
+        jr .ToggleOff
+
+.NonePressed:
+        bit CHALLENGE_MODE, [hl]
+        jr nz, .ToggleOn
+
+.ToggleOff:
+        res CHALLENGE_MODE, [hl]
+        ld de, .Off
+        jr .Display
+
+.ToggleOn:
+        set CHALLENGE_MODE, [hl]
+        ld de, .On
+
+.Display:
+        hlcoord 11, 13
+        rst PlaceString
+        and a
+        ret
 
 .Off: db "OFF@"
 .On:  db "ON @"
@@ -505,16 +441,16 @@ OptionsControl:
 
 .DownPressed:
 	ld a, [hl]
-	cp OPT_CANCEL ; maximum option index
-	jr nz, .CheckMenuAccount
+        cp OPT_CANCEL ; maximum option index
+        jr nz, .CheckChallengeMode
 	ld [hl], OPT_TEXT_SPEED ; first option
 	scf
 	ret
 
-.CheckMenuAccount: ; I have no idea why this exists...
-	cp OPT_MENU_ACCOUNT
-	jr nz, .Increase
-	ld [hl], OPT_MENU_ACCOUNT
+.CheckChallengeMode: ; I have no idea why this exists...
+        cp OPT_CHALLENGE_MODE
+        jr nz, .Increase
+        ld [hl], OPT_CHALLENGE_MODE
 
 .Increase:
 	inc [hl]
@@ -525,9 +461,9 @@ OptionsControl:
 	ld a, [hl]
 
 ; Another thing where I'm not sure why it exists
-	cp OPT_FRAME
-	jr nz, .NotFrame
-	ld [hl], OPT_MENU_ACCOUNT
+        cp OPT_FRAME
+        jr nz, .NotFrame
+        ld [hl], OPT_CHALLENGE_MODE
 	scf
 	ret
 

--- a/engine/menus/start_menu.asm
+++ b/engine/menus/start_menu.asm
@@ -27,11 +27,11 @@ StartMenu::
 .GotMenuData:
 	call LoadMenuHeader
 	call .SetUpMenuItems
-	ld a, [wBattleMenuCursorPosition]
-	ld [wMenuCursorPosition], a
-	call .DrawDayTimeBox
-	call .DrawMenuAccount
-	call DrawVariableLengthMenuBox
+        ld a, [wBattleMenuCursorPosition]
+        ld [wMenuCursorPosition], a
+        call .DrawDayTimeBox
+        call .DrawMenuAccount
+        call DrawVariableLengthMenuBox
 	call .DrawBugContestStatusBox
 	call SafeUpdateSprites
 	call HDMATransferTilemapAndAttrmap_Menu
@@ -48,11 +48,11 @@ StartMenu::
 	ld [wMenuCursorPosition], a
 
 .Select:
-	call .GetInput
-	jr c, .Exit
-	call .DrawDayTimeBox
-	call .DrawMenuAccount
-	ld a, [wMenuCursorPosition]
+        call .GetInput
+        jr c, .Exit
+        call .DrawDayTimeBox
+        call .DrawMenuAccount
+        ld a, [wMenuCursorPosition]
 	ld [wBattleMenuCursorPosition], a
 	call PlayClickSFX
 	call PlaceHollowCursor
@@ -97,16 +97,16 @@ StartMenu::
 ; Return carry on exit, and no-carry on selection.
 	xor a
 	ldh [hBGMapMode], a
-	call .DrawDayTimeBox
-	call .DrawMenuAccount
-	call SetUpMenu
-	ld a, $ff
+        call .DrawDayTimeBox
+        call .DrawMenuAccount
+        call SetUpMenu
+        ld a, $ff
 	ld [wMenuSelection], a
 .loop
-	call .PrintDayTime
-	call .PrintMenuAccount
-	call GetScrollingMenuJoypad
-	ld a, [wMenuJoypad]
+        call .PrintDayTime
+        call .PrintMenuAccount
+        call GetScrollingMenuJoypad
+        ld a, [wMenuJoypad]
 	cp PAD_B
 	jr z, .b
 	cp PAD_A
@@ -148,13 +148,13 @@ StartMenu::
 	call ClearBGPalettes
 	call ExitMenu
 	call ReloadTilesetAndPalettes
-	call .DrawDayTimeBox
-	call .DrawMenuAccount
-	call DrawVariableLengthMenuBox
-	call .DrawBugContestStatus
-	call UpdateSprites
-	call FinishExitMenu
-	jmp .Reopen
+        call .DrawDayTimeBox
+        call .DrawMenuAccount
+        call DrawVariableLengthMenuBox
+        call .DrawBugContestStatus
+        call UpdateSprites
+        call FinishExitMenu
+        jmp .Reopen
 
 .MenuHeader:
 	db MENU_BACKUP_TILES ; flags
@@ -354,36 +354,36 @@ endr
 	ret
 
 .AppendMenuList:
-	ld [de], a
-	inc de
-	inc c
-	ret
+        ld [de], a
+        inc de
+        inc c
+        ret
 
 .PrintMenuAccount:
-	call .IsMenuAccountOn
-	ret z
-	call .DrawMenuAccount
-	decoord 1, 15
-	jmp .MenuDesc
+       call .IsMenuAccountOn
+       ret z
+       call .DrawMenuAccount
+       decoord 1, 15
+       jmp .MenuDesc
 
 .DrawMenuAccount:
-	call .IsMenuAccountOn
-	ret z
-	hlcoord 0, 14
-	lb bc, 4, 10
-	call ClearBox
-	hlcoord 0, 14
-	lb bc, 4, 8
-	jmp TextboxPalette
+       call .IsMenuAccountOn
+       ret z
+       hlcoord 0, 14
+       lb bc, 4, 10
+       call ClearBox
+       hlcoord 0, 14
+       lb bc, 4, 8
+       jmp TextboxPalette
 
 .IsMenuAccountOn:
-	ld a, [wOptions2]
-	and 1 << MENU_ACCOUNT
-	ret
-	
+       ld a, [wOptions2]
+       and 1 << MENU_ACCOUNT
+       ret
+
 .DrawDayTimeBox: ; 128b4
-	hlcoord 0, 0
-	lb bc, 2, 10
+        hlcoord 0, 0
+        lb bc, 2, 10
 	call ClearBox
 	hlcoord 0, 0
 	lb bc, 0, 8

--- a/engine/overworld/scripting.asm
+++ b/engine/overworld/scripting.asm
@@ -232,11 +232,12 @@ ScriptCommandTable:
 	dw Script_checksave                  ; a9
 	dw Script_loadmonindex               ; aa
 	dw Script_checkmaplockedmons         ; ab
-	dw Script_loaditemindex              ; ac
-	dw Script_checkmaplockeditems        ; ad
-	dw Script_givepokemove               ; ae
-	dw Script_berrysound               ; af
-	assert_table_length NUM_EVENT_COMMANDS
+        dw Script_loaditemindex              ; ac
+        dw Script_checkmaplockeditems        ; ad
+        dw Script_givepokemove               ; ae
+        dw Script_berrysound               ; af
+        dw Script_checkcm                  ; b0
+        assert_table_length NUM_EVENT_COMMANDS
 
 StartScript:
 	ld hl, wScriptFlags
@@ -1991,12 +1992,22 @@ Script_checkflag:
 	ret
 
 _EngineFlagAction:
-	farjp EngineFlagAction
+        farjp EngineFlagAction
+
+Script_checkcm:
+        xor a
+        ld [wScriptVar], a
+        ld a, [wOptions2]
+        bit CHALLENGE_MODE, a
+        ret z
+        ld a, TRUE
+        ld [wScriptVar], a
+        ret
 
 Script_wildoff:
-	ld hl, wStatusFlags
-	set STATUSFLAGS_NO_WILD_ENCOUNTERS_F, [hl]
-	ret
+        ld hl, wStatusFlags
+        set STATUSFLAGS_NO_WILD_ENCOUNTERS_F, [hl]
+        ret
 
 Script_wildon:
 	ld hl, wStatusFlags

--- a/macros/scripts/events.asm
+++ b/macros/scripts/events.asm
@@ -1102,9 +1102,14 @@ MACRO givepokemove
 	assert (\3 >= 0) && (\3 < 4), "givepokemove Move Number \3 is not 0-3!"
 ENDM
 
-	const berrysound_command ; $af
+        const berrysound_command ; $af
 MACRO berrysound
-	db berrysound_command
+        db berrysound_command
+ENDM
+
+        const checkcm_command ; $b0
+MACRO checkcm
+        db checkcm_command
 ENDM
 
 DEF NUM_EVENT_COMMANDS EQU const_value

--- a/maps/MikanGym.asm
+++ b/maps/MikanGym.asm
@@ -143,12 +143,18 @@ MikanGymCissyScript:
 	writetext CissyBeforeBattleText
 	waitbutton
 	closetext
-	winlosstext CissyBeatenText, 0
-	setlasttalked MIKAN_GYM_CISSY
-	loadtrainer CISSY, CISSY1
-	startbattle
-	reloadmapafterbattle
-	sjump .AfterBattle
+        winlosstext CissyBeatenText, 0
+        setlasttalked MIKAN_GYM_CISSY
+        checkcm
+        iffalse .LoadCissy
+        loadtrainer RED, RED1
+        sjump .StartBattle
+.LoadCissy
+        loadtrainer CISSY, CISSY1
+.StartBattle
+        startbattle
+        reloadmapafterbattle
+        sjump .AfterBattle
 .AfterBattle:
 	setevent EVENT_CISSY_DEFEATED
 	setevent EVENT_BEAT_SWIMMER_F_ALLIE

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1584,8 +1584,9 @@ wGBPrinterBrightness::
 ;   darkest:  $7F
 	db
 wOptions2::
-; bit 1: menu account off/on
-	db
+; bit 0: menu account off/on
+; bit 1: challenge mode off/on
+        db
 	ds 2
 wOptionsEnd::
 


### PR DESCRIPTION
## Summary
- add `checkcm` script command and handler to read the Challenge Mode flag
- switch Mikan Gym's Cissy battle to use `checkcm` before loading Red's data
- document the new `checkcm` event command
- replace the obsolete printer option with a Menu Account toggle while keeping Challenge Mode separate

## Testing
- `apt-get install -y rgbds` *(fails: Unable to locate package rgbds)*
- `make` *(fails: rgbasm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbe6eae88832597b874ab87386b54