### PR TITLE
Add Oak Challenge option and gym gate

### DIFF
--- a/constants/ram_constants.asm
+++ b/constants/ram_constants.asm
@@ -76,7 +76,7 @@ DEF GBPRINTER_DARKEST  EQU $7f
 
 ; wOptions2::
         const_def
-        const MENU_ACCOUNT   ; 0
+        const OAK_CHALLENGE  ; 0
         const CHALLENGE_MODE ; 1
 
 ; wDST::

--- a/data/default_options.asm
+++ b/data/default_options.asm
@@ -9,8 +9,8 @@ DefaultOptions:
 	db 1 << FAST_TEXT_DELAY_F
 ; wGBPrinterBrightness: normal
 	db GBPRINTER_NORMAL
-; wOptions2: menu account on, challenge mode off
-        db 1 << MENU_ACCOUNT
+; wOptions2: oak challenge off, challenge mode off
+        db 0
 
 	db $00
 	db $00

--- a/docs/event_commands.md
+++ b/docs/event_commands.md
@@ -564,3 +564,9 @@ If <code><i>item_id</i></code> = `USE_SCRIPT_VAR`, then it uses `[wScriptVar]` i
 
 ## `$B0`: `checkcm`
 Sets `VAR` to `TRUE` if Challenge Mode is enabled; otherwise `FALSE`.
+
+## `$B1`: `checkdex`
+Stores the number of Pokémon caught in `VAR`.
+
+## `$B2`: `checkoak`
+Sets `VAR` to `TRUE` if the Oak Challenge is enabled; otherwise `FALSE`.

--- a/engine/menus/options_menu.asm
+++ b/engine/menus/options_menu.asm
@@ -4,7 +4,7 @@
 	const OPT_BATTLE_SCENE  ; 1
 	const OPT_BATTLE_STYLE  ; 2
         const OPT_SOUND         ; 3
-        const OPT_MENU_ACCOUNT  ; 4
+        const OPT_OAK_CHALLENGE ; 4
         const OPT_CHALLENGE_MODE ; 5
         const OPT_FRAME         ; 6
         const OPT_CANCEL        ; 7
@@ -82,7 +82,7 @@ StringOptions:
 	db "        :<LF>"
         db "SOUND<LF>"
         db "        :<LF>"
-        db "MENU ACCOUNT<LF>"
+        db "OAK CHALLENGE<LF>"
         db "        :<LF>"
         db "CHALLENGE MODE<LF>"
         db "        :<LF>"
@@ -99,7 +99,7 @@ GetOptionPointer:
 	dw Options_BattleScene
 	dw Options_BattleStyle
         dw Options_Sound
-        dw Options_MenuAccount
+        dw Options_OakChallenge
         dw Options_ChallengeMode
 	dw Options_Frame
 	dw Options_Cancel
@@ -311,33 +311,33 @@ Options_Sound:
 .Mono:   db "MONO  @"
 .Stereo: db "STEREO@"
 
-Options_MenuAccount:
+Options_OakChallenge:
         ld hl, wOptions2
         ldh a, [hJoyPressed]
         bit B_PAD_LEFT, a
         jr nz, .LeftPressed
         bit B_PAD_RIGHT, a
         jr z, .NonePressed
-        bit MENU_ACCOUNT, [hl]
+        bit OAK_CHALLENGE, [hl]
         jr nz, .ToggleOff
         jr .ToggleOn
 
 .LeftPressed:
-        bit MENU_ACCOUNT, [hl]
+        bit OAK_CHALLENGE, [hl]
         jr z, .ToggleOn
         jr .ToggleOff
 
 .NonePressed:
-        bit MENU_ACCOUNT, [hl]
+        bit OAK_CHALLENGE, [hl]
         jr nz, .ToggleOn
 
 .ToggleOff:
-        res MENU_ACCOUNT, [hl]
+        res OAK_CHALLENGE, [hl]
         ld de, .Off
         jr .Display
 
 .ToggleOn:
-        set MENU_ACCOUNT, [hl]
+        set OAK_CHALLENGE, [hl]
         ld de, .On
 
 .Display:

--- a/engine/menus/start_menu.asm
+++ b/engine/menus/start_menu.asm
@@ -53,7 +53,7 @@ StartMenu::
         call .DrawDayTimeBox
         call .DrawMenuAccount
         ld a, [wMenuCursorPosition]
-	ld [wBattleMenuCursorPosition], a
+        ld [wBattleMenuCursorPosition], a
 	call PlayClickSFX
 	call PlaceHollowCursor
 	call .OpenMenu
@@ -95,13 +95,13 @@ StartMenu::
 
 .GetInput:
 ; Return carry on exit, and no-carry on selection.
-	xor a
-	ldh [hBGMapMode], a
+        xor a
+        ldh [hBGMapMode], a
         call .DrawDayTimeBox
         call .DrawMenuAccount
         call SetUpMenu
         ld a, $ff
-	ld [wMenuSelection], a
+        ld [wMenuSelection], a
 .loop
         call .PrintDayTime
         call .PrintMenuAccount
@@ -143,11 +143,11 @@ StartMenu::
 	jr .ReturnEnd2
 
 .ReturnRedraw:
-	farcall ClearSavedObjPals
-	farcall DisableDynPalUpdates
-	call ClearBGPalettes
-	call ExitMenu
-	call ReloadTilesetAndPalettes
+        farcall ClearSavedObjPals
+        farcall DisableDynPalUpdates
+        call ClearBGPalettes
+        call ExitMenu
+        call ReloadTilesetAndPalettes
         call .DrawDayTimeBox
         call .DrawMenuAccount
         call DrawVariableLengthMenuBox
@@ -235,7 +235,7 @@ StartMenu::
 
 .OpenMenu:
 	ld a, [wMenuSelection]
-	call .GetMenuAccountTextPointer
+        call .GetMenuTextPointer
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
@@ -244,7 +244,7 @@ StartMenu::
 .MenuString:
 	push de
 	ld a, [wMenuSelection]
-	call .GetMenuAccountTextPointer
+        call .GetMenuTextPointer
 	inc hl
 	inc hl
 	ld a, [hli]
@@ -258,7 +258,7 @@ StartMenu::
 	ld a, [wMenuSelection]
 	cp $ff
 	jr z, .none
-	call .GetMenuAccountTextPointer
+        call .GetMenuTextPointer
 rept 4
 	inc hl
 endr
@@ -271,7 +271,7 @@ endr
 	pop de
 	ret
 
-.GetMenuAccountTextPointer:
+.GetMenuTextPointer:
 	ld e, a
 	ld d, 0
 	ld hl, wMenuDataPointerTableAddr
@@ -359,32 +359,25 @@ endr
         inc c
         ret
 
+
 .PrintMenuAccount:
-       call .IsMenuAccountOn
-       ret z
-       call .DrawMenuAccount
-       decoord 1, 15
-       jmp .MenuDesc
+        call .DrawMenuAccount
+        decoord 1, 15
+        jmp .MenuDesc
 
 .DrawMenuAccount:
-       call .IsMenuAccountOn
-       ret z
-       hlcoord 0, 14
-       lb bc, 4, 10
-       call ClearBox
-       hlcoord 0, 14
-       lb bc, 4, 8
-       jmp TextboxPalette
+        hlcoord 0, 14
+        lb bc, 4, 10
+        call ClearBox
+        hlcoord 0, 14
+        lb bc, 4, 8
+        jmp TextboxPalette
 
-.IsMenuAccountOn:
-       ld a, [wOptions2]
-       and 1 << MENU_ACCOUNT
-       ret
 
 .DrawDayTimeBox: ; 128b4
         hlcoord 0, 0
         lb bc, 2, 10
-	call ClearBox
+        call ClearBox
 	hlcoord 0, 0
 	lb bc, 0, 8
 	jmp TextboxPalette

--- a/engine/overworld/scripting.asm
+++ b/engine/overworld/scripting.asm
@@ -237,6 +237,8 @@ ScriptCommandTable:
         dw Script_givepokemove               ; ae
         dw Script_berrysound               ; af
         dw Script_checkcm                  ; b0
+        dw Script_checkdex                 ; b1
+        dw Script_checkoak                 ; b2
         assert_table_length NUM_EVENT_COMMANDS
 
 StartScript:
@@ -1999,6 +2001,23 @@ Script_checkcm:
         ld [wScriptVar], a
         ld a, [wOptions2]
         bit CHALLENGE_MODE, a
+        ret z
+        ld a, TRUE
+        ld [wScriptVar], a
+        ret
+
+Script_checkdex:
+        ld a, VAR_DEXCAUGHT
+        call GetVarAction
+        ld a, [de]
+        ld [wScriptVar], a
+        ret
+
+Script_checkoak:
+        xor a
+        ld [wScriptVar], a
+        ld a, [wOptions2]
+        bit OAK_CHALLENGE, a
         ret z
         ld a, TRUE
         ld [wScriptVar], a

--- a/macros/scripts/events.asm
+++ b/macros/scripts/events.asm
@@ -1112,4 +1112,14 @@ MACRO checkcm
         db checkcm_command
 ENDM
 
+        const checkdex_command ; $b1
+MACRO checkdex
+        db checkdex_command
+ENDM
+
+        const checkoak_command ; $b2
+MACRO checkoak
+        db checkoak_command
+ENDM
+
 DEF NUM_EVENT_COMMANDS EQU const_value

--- a/maps/MikanGym.asm
+++ b/maps/MikanGym.asm
@@ -136,13 +136,18 @@ MikanGymFemaleGuardText:
 	done
 	
 MikanGymCissyScript:
-	faceplayer
-	opentext
-	checkflag ENGINE_CORALEYEBADGE
-	iftrue .FightDone
-	writetext CissyBeforeBattleText
-	waitbutton
-	closetext
+        faceplayer
+        opentext
+        checkflag ENGINE_CORALEYEBADGE
+        iftrue .FightDone
+        checkoak
+        iffalse .NoOakChallenge
+        checkdex
+        ifless 10, .NeedMorePokemon
+.NoOakChallenge:
+        writetext CissyBeforeBattleText
+        waitbutton
+        closetext
         winlosstext CissyBeatenText, 0
         setlasttalked MIKAN_GYM_CISSY
         checkcm
@@ -155,9 +160,14 @@ MikanGymCissyScript:
         startbattle
         reloadmapafterbattle
         sjump .AfterBattle
+.NeedMorePokemon:
+        writetext CissyOakChallengeText
+        waitbutton
+        closetext
+        end
 .AfterBattle:
-	setevent EVENT_CISSY_DEFEATED
-	setevent EVENT_BEAT_SWIMMER_F_ALLIE
+        setevent EVENT_CISSY_DEFEATED
+        setevent EVENT_BEAT_SWIMMER_F_ALLIE
 	setevent EVENT_BEAT_SWIMMER_F_MORGAN
 	setevent EVENT_BEAT_BEAUTY_YEVON
 	setevent EVENT_BEAT_SWIMMER_M_BRAD
@@ -214,23 +224,29 @@ CissyBeforeBattleText:
 	done
 
 CissyBeatenText:
-	text "CISSY: What?!"
+        text "CISSY: What?!"
 
-	para "My perfect WATER"
-	line "#MON!"
+        para "My perfect WATER"
+        line "#MON!"
 
 	para "Very well! You've"
 	line "earned this."
 
 	para "It's the official"
 	line "ORANGE CREW"
-	cont "CORAL-EYE BADGE."
-	done
+        cont "CORAL-EYE BADGE."
+        done
+
+CissyOakChallengeText:
+        text "CISSY: OAK says"
+        line "you need 10" 
+        cont "#MON to fight!"
+        done
 
 PlayerReceivedCoralEyeBadgeText:
-	text "<PLAYER> received"
-	line "CORAL-EYE BADGE."
-	done
+        text "<PLAYER> received"
+        line "CORAL-EYE BADGE."
+        done
 
 CissyExplainTMText:
 	text "CISSY: You fought"

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1584,7 +1584,7 @@ wGBPrinterBrightness::
 ;   darkest:  $7F
 	db
 wOptions2::
-; bit 0: menu account off/on
+; bit 0: oak challenge off/on
 ; bit 1: challenge mode off/on
         db
 	ds 2


### PR DESCRIPTION
## Summary
- replace Menu Account with a new Oak Challenge option that's off by default
- add `checkoak` script command to query the Oak Challenge state
- block Cissy's battle in Mikan Gym unless 10 Pokémon are caught when Oak Challenge is active
- always draw the Menu Account on the start menu regardless of options

## Testing
- `make crystal`


------
https://chatgpt.com/codex/tasks/task_e_68bd40b5644883258a680ca4e24f14f2